### PR TITLE
Rename method to adhere to spec

### DIFF
--- a/src/Api/TransportReader.php
+++ b/src/Api/TransportReader.php
@@ -52,7 +52,7 @@ class TransportReader implements TransportInterface
     /**
      * @return array
      */
-    public function getOrigin(): array
+    public function getOriginService(): array
     {
         return $this->transport->getMeta()->getOrigin();
     }

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -40,7 +40,7 @@ interface Transport
      *
      * @return array
      */
-    public function getOrigin(): array;
+    public function getOriginService(): array;
 
     /**
      * Get a custom userland property


### PR DESCRIPTION
Rename `getOrigin()` method as discussed in https://github.com/kusanagi/katana-sdk-spec/pull/15