### PR TITLE
Support for Katana 1.0.15

### DIFF
--- a/src/Api/ActionApi.php
+++ b/src/Api/ActionApi.php
@@ -439,6 +439,7 @@ class ActionApi extends Api implements Action
             $service,
             $versionString,
             $action,
+            0,
             $params
         ));
 
@@ -498,6 +499,7 @@ class ActionApi extends Api implements Action
             $service,
             $versionString,
             $action,
+            0,
             $timeout,
             $params
         ));

--- a/src/Api/DeferCall.php
+++ b/src/Api/DeferCall.php
@@ -50,6 +50,11 @@ class DeferCall
     private $action;
 
     /**
+     * @var int
+     */
+    private $duration = 0;
+
+    /**
      * @var Param[]
      */
     private $params = [];
@@ -66,6 +71,7 @@ class DeferCall
      * @param string $service
      * @param VersionString $version
      * @param string $action
+     * @param int $duration
      * @param Param[] $params
      * @param File[] $files
      */
@@ -75,6 +81,7 @@ class DeferCall
         $service,
         VersionString $version,
         $action,
+        int $duration,
         array $params = [],
         array $files = []
     ) {
@@ -83,6 +90,7 @@ class DeferCall
         $this->service = $service;
         $this->version = $version;
         $this->action = $action;
+        $this->duration = $duration;
         $this->params = $params;
         $this->files = $files;
     }
@@ -125,6 +133,14 @@ class DeferCall
     public function getAction()
     {
         return $this->action;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDuration(): int
+    {
+        return $this->duration;
     }
 
     /**

--- a/src/Api/RemoteCall.php
+++ b/src/Api/RemoteCall.php
@@ -36,6 +36,7 @@ class RemoteCall extends DeferCall
      * @param string $service
      * @param VersionString $version
      * @param string $action
+     * @param int $duration
      * @param int $timeout
      * @param Param[] $params
      * @param File[] $files
@@ -47,11 +48,12 @@ class RemoteCall extends DeferCall
         $service,
         VersionString $version,
         $action,
+        int $duration,
         $timeout,
         $params = [],
         $files = []
     ) {
-        parent::__construct($origin, $caller, $service, $version, $action, $params, $files);
+        parent::__construct($origin, $caller, $service, $version, $action, $duration, $params, $files);
         $this->address = $address;
         $this->timeout = $timeout;
     }

--- a/src/Api/TransportCalls.php
+++ b/src/Api/TransportCalls.php
@@ -85,6 +85,7 @@ class TransportCalls
                 'n' => $call->getService(),
                 'v' => $call->getVersion(),
                 'a' => $call->getAction(),
+                'd' => $call->getDuration(),
                 'p' => array_map(function (Param $param) {
                     return [
                         'n' => $param->getName(),

--- a/src/Api/TransportMeta.php
+++ b/src/Api/TransportMeta.php
@@ -36,11 +36,32 @@ class TransportMeta
     private $id;
 
     /**
-     * Datetime of the process in UTC and ISO 8601
+     * Datetime of the process in UTC and ISO 8601.
      *
      * @var string
      */
     private $datetime;
+
+    /**
+     * The datetime of the start of the current call in UTC and ISO 8601.
+     *
+     * @var string
+     */
+    private $startTime;
+
+    /**
+     * The datetime of the end of the current call in UTC and ISO 8601.
+     *
+     * @var string
+     */
+    private $endTime;
+
+    /**
+     * Execution time in milliseconds spent by the origin service.
+     *
+     * @var int
+     */
+    private $duration;
 
     /**
      * The address of the Gateway serving the HTTP request.
@@ -81,6 +102,9 @@ class TransportMeta
      * @param string $version
      * @param string $id
      * @param string $datetime
+     * @param string $startTime
+     * @param string $endTime
+     * @param int $duration
      * @param string $gateway
      * @param array $origin
      * @param int $level
@@ -91,6 +115,9 @@ class TransportMeta
         $version,
         $id,
         $datetime,
+        $startTime,
+        $endTime,
+        $duration,
         $gateway,
         array $origin,
         $level,
@@ -100,6 +127,9 @@ class TransportMeta
         $this->version = $version;
         $this->id = $id;
         $this->datetime = $datetime;
+        $this->startTime = $startTime;
+        $this->endTime = $endTime;
+        $this->duration = $duration;
         $this->gateway = $gateway;
         $this->origin = $origin;
         $this->level = $level;
@@ -129,6 +159,30 @@ class TransportMeta
     public function getDatetime()
     {
         return $this->datetime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStartTime(): string
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndTime(): string
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDuration(): int
+    {
+        return $this->duration;
     }
 
     /**

--- a/src/Api/TransportReader.php
+++ b/src/Api/TransportReader.php
@@ -58,6 +58,14 @@ class TransportReader implements TransportInterface
     }
 
     /**
+     * @return int
+     */
+    public function getOriginDuration(): int
+    {
+        return $this->transport->getMeta()->getDuration();
+    }
+
+    /**
      * @param string $name
      * @param string $default
      * @return string

--- a/src/Mapper/CompactTransportMapper.php
+++ b/src/Mapper/CompactTransportMapper.php
@@ -114,6 +114,9 @@ class CompactTransportMapper
             $rawMeta['v'],
             $rawMeta['i'],
             $rawMeta['d'],
+            $rawMeta['s'] ?? '',
+            $rawMeta['e'] ?? '',
+            $rawMeta['D'] ?? 0,
             $rawMeta['g'],
             $rawMeta['o'],
             $rawMeta['l'],
@@ -132,6 +135,9 @@ class CompactTransportMapper
             'v' => $meta->getVersion(),
             'i' => $meta->getId(),
             'd' => $meta->getDatetime(),
+            's' => $meta->getStartTime(),
+            'e' => $meta->getEndTime(),
+            'D' => $meta->getDuration(),
             'g' => $meta->getGateway(),
             'o' => $meta->getOrigin(),
             'l' => $meta->getLevel(),
@@ -357,6 +363,7 @@ class CompactTransportMapper
                         $callData['n'],
                         new VersionString($callData['v']),
                         $callData['a'],
+                        $callData['D'] ?? 0,
                         isset($callData['p'])? array_map([$this, 'getParam'], $callData['p']) : []
                     );
                 }, $versionCalls);
@@ -378,6 +385,7 @@ class CompactTransportMapper
                 'n' => $call->getService(),
                 'v' => $call->getVersion(),
                 'a' => $call->getAction(),
+                'D' => $call->getDuration(),
                 'C' => $call->getCaller(),
             ];
 
@@ -607,6 +615,7 @@ class CompactTransportMapper
                         $vCalls['n'],
                         new VersionString($vCalls['v']),
                         $vCalls['a'],
+                        $vCalls['D'] ?? 0,
                         $vCalls['t'],
                         isset($vCalls['p'])? array_map([$this, 'getParam'], $vCalls['p']) : []
                     );
@@ -617,6 +626,7 @@ class CompactTransportMapper
                         $vCalls['n'],
                         new VersionString($vCalls['v']),
                         $vCalls['a'],
+                        $vCalls['D'] ?? 0,
                         isset($vCalls['p'])? array_map([$this, 'getParam'], $vCalls['p']) : []
                     );
                 }

--- a/src/Mapper/ExtendedTransportMapper.php
+++ b/src/Mapper/ExtendedTransportMapper.php
@@ -114,6 +114,9 @@ class ExtendedTransportMapper
             $rawMeta['version'],
             $rawMeta['id'],
             $rawMeta['datetime'],
+            $rawMeta['start_time'],
+            $rawMeta['end_time'],
+            $rawMeta['duration'],
             $rawMeta['gateway'],
             $rawMeta['origin'],
             $rawMeta['level'],
@@ -132,6 +135,9 @@ class ExtendedTransportMapper
             'version' => $meta->getVersion(),
             'id' => $meta->getId(),
             'datetime' => $meta->getDatetime(),
+            'start_time' => $meta->getStartTime(),
+            'end_time' => $meta->getEndTime(),
+            'duration' => $meta->getDuration(),
             'gateway' => $meta->getGateway(),
             'origin' => $meta->getOrigin(),
             'level' => $meta->getLevel(),
@@ -347,6 +353,7 @@ class ExtendedTransportMapper
                             $callData['name'],
                             new VersionString($callData['version']),
                             $callData['action'],
+                            $callData['duration'],
                             isset($callData['params'])? array_map([$this, 'getParam'], $callData['params']) : []
                         );
                     }, $versionCalls);
@@ -369,6 +376,7 @@ class ExtendedTransportMapper
                 'name' => $call->getService(),
                 'version' => $call->getVersion(),
                 'action' => $call->getAction(),
+                'duration' => $call->getDuration(),
                 'caller' => $call->getCaller(),
             ];
 

--- a/src/Messaging/RuntimeCaller/ZeroMQRuntimeCaller.php
+++ b/src/Messaging/RuntimeCaller/ZeroMQRuntimeCaller.php
@@ -132,7 +132,7 @@ class ZeroMQRuntimeCaller
                 throw new RuntimeCallException("Error response: {$response['E']['m']}");
             } else {
                 echo json_encode($response), "\n";
-                $return = $response['cr']['r']['R'];
+                $return = $response['cr']['r']['rv'];
                 $this->mapper->merge($transport, $response['cr']['r']['T']);
             }
 


### PR DESCRIPTION
Support for the payload of katana 1.0.15.

Includes a rename in the return value key and support for duration of calls.