### PR TITLE
Remove call duplicates

### DIFF
--- a/src/Mapper/CompactTransportMapper.php
+++ b/src/Mapper/CompactTransportMapper.php
@@ -671,42 +671,6 @@ class CompactTransportMapper implements TransportWriterInterface, TransportReade
         }
         $transport->mergeLinks(...$links);
 
-        // Merge calls
-        foreach ($mergeData['C'] ?? [] as $service => $sCalls) {
-            foreach ($sCalls as $version => $vCalls) {
-                foreach ($vCalls as $vCall) {
-                    if (!isset($vCall['D']) || $vCall['D'] === 0) {
-                        continue;
-                    }
-
-                    if (isset($vCall['g'])) {
-                        $call = new RemoteCall(
-                            new ServiceOrigin($service, $version),
-                            $vCall['C'],
-                            $vCall['g'],
-                            $vCall['n'],
-                            new VersionString($vCall['v']),
-                            $vCall['a'],
-                            $vCall['D'] ?? 0,
-                            $vCall['t'],
-                            isset($vCall['p']) ? array_map([$this, 'getParam'], $vCall['p']) : []
-                        );
-                    } else {
-                        $call = new DeferCall(
-                            new ServiceOrigin($service, $version),
-                            $vCall['C'],
-                            $vCall['n'],
-                            new VersionString($vCall['v']),
-                            $vCall['a'],
-                            $vCall['D'] ?? 0,
-                            isset($vCall['p']) ? array_map([$this, 'getParam'], $vCall['p']) : []
-                        );
-                    }
-                    $transport->addCall($call);
-                }
-            }
-        }
-
         // Merge Transactions
         foreach ($mergeData['t'] ?? [] as $type => $transaction) {
             $type = [

--- a/src/Mapper/CompactTransportMapper.php
+++ b/src/Mapper/CompactTransportMapper.php
@@ -560,9 +560,9 @@ class CompactTransportMapper implements TransportWriterInterface, TransportReade
                             $address,
                             $service,
                             $version,
-                            $errorData['m'],
-                            $errorData['c'],
-                            $errorData['s']
+                            $errorData['m'] ?? 'Unknown error',
+                            $errorData['c'] ?? 0,
+                            $errorData['s'] ?? '500 Internal Server Error'
                         );
                     }, $versionErrors);
                 }


### PR DESCRIPTION
Merging calls after a runtime call brings the problem that the runtime calls are both in the transport sent and in the received one. Merging them will duplicate them on each runtime call, causing that doing more than 2 result in an exponential increase of memory consumed, that can kill a server if more than 10 are done.